### PR TITLE
Assign convenience method

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,5 @@ Implemented methods
 - [x] `__getitem__` - `glom.glom()`
 - [x] `__setitem__` - `glom.assign()`
 - [x] `__delitem__` - `glom.delete()`
+- [x] `assign` - `glom.assign()` - can pass `missing` callable to automatically backfill missing structures.
 - [ ] `update` - Works but no special behavior

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "glom-dict"
-version = "0.0.1a"
+version = "0.0.2a"
 description = "Custom Dictionary with glom get, set and del methods"
 authors = ["Gabriel <gabriel59kg@gmail.com>"]
 license = "MIT License"

--- a/src/glom_dict/__main__.py
+++ b/src/glom_dict/__main__.py
@@ -1,6 +1,6 @@
 import collections
 import logging
-from typing import Any, Hashable, Union
+from typing import Any, Callable, Hashable, Union, Optional
 
 import glom as g
 
@@ -26,6 +26,7 @@ class GlomDict(collections.UserDict, dict):
       __getitem__
       __setitem__
       __delitem__
+      assign
     """
 
     def __getitem__(self, key: GlomDictKey):
@@ -36,3 +37,10 @@ class GlomDict(collections.UserDict, dict):
 
     def __delitem__(self, key: GlomDictKey):
         g.delete(self, key)
+
+    def assign(self, path: GlomDictKey, val: Any, missing: Optional[Callable] = None):
+        return g.assign(self.data, path, val=val, missing=missing)
+
+
+# use the glom assign docs function docs
+GlomDict.assign.__doc__ = g.assign.__doc__

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,6 @@
 """Tests for the `cli` module."""
 import collections
+from pprint import pformat as pf
 
 import glom as g
 import pytest
@@ -81,6 +82,36 @@ class TestSetItem:
         str_path = ".".join(str(p) for p in path.values())
         gd[str_path] = value
         assert gd[str_path] == value
+
+
+class TestAssign:
+    @pytest.mark.parametrize(
+        "path, value",
+        [
+            (g.Path("a", "b", "c"), "D"),
+            (g.Path("a_list", 2), "ANOTHER_NEEDLE"),
+        ],
+    )
+    def test_simple_assignment(self, sample, path: g.Path, value):
+        gd = GlomDict(**sample)
+
+        glom_path = g.Path(*path)
+        gd.assign(glom_path, value)
+        assert gd[glom_path] == value
+
+    @pytest.mark.parametrize(
+        "path, value, missing",
+        [
+            (g.Path("a", "KEY", "THAT", "DOES NOT"), "EXIST", dict),
+            (g.Path("NEEDS", "BACKFILL"), {"foo": "bar"}, dict),
+        ],
+    )
+    def test_assignment_backfill(self, sample, path: g.Path, value, missing):
+        gd = GlomDict(**sample)
+
+        gd.assign(path, value, missing=missing)
+        print(pf(gd, depth=2))
+        assert gd[path] == value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Enables passing the `missing` callable.

From [glom docs](https://glom.readthedocs.io/en/latest/mutation.html?highlight=assign#glom.Assign)
>To automatically backfill missing structures, you can pass a callable to the missing argument. This callable will be called for each path segment along the assignment which is not present.